### PR TITLE
uploads/settings.py: Tweaks for django 2.2

### DIFF
--- a/uploads/settings.py
+++ b/uploads/settings.py
@@ -41,13 +41,12 @@ INSTALLED_APPS = [
     'uploads.core'
 ]
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]


### PR DESCRIPTION
The example doesn't run under django 2.2.  These changes allow it to run.